### PR TITLE
Enable trust-remote-code for vLLM server

### DIFF
--- a/gen-ai-inference-testing/openai_server/vllm/run.sh
+++ b/gen-ai-inference-testing/openai_server/vllm/run.sh
@@ -35,7 +35,6 @@ max-num-seqs: $MAX_NUM_SEQS
 dtype: auto
 max-model-len: $MAX_MODEL_LEN
 max-num-batched-tokens: $MAX_MODEL_LEN
-trust-remote-code: true
 EOF
 
 # Add V0-specific options for Neuron


### PR DESCRIPTION
*Issue #, if available:*
Fixes issue where multimodal models fail to load with ValidationError.

*Description of changes:*
 Add trust-remote-code: true to the vLLM config to support models that require custom modeling code (e.g., Phi-3-Vision). This flag is safe for all models and only affects those with custom code.

  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
